### PR TITLE
Skip reading from stdin via `cat -` if not receiving data through stdin

### DIFF
--- a/vipe.sh
+++ b/vipe.sh
@@ -49,7 +49,6 @@ then :; else
 fi
 trap clean_up EXIT
 
-
 if cat - > "${temp_file}"
 then :; else
 	err cat "${?}" "Failed to save standard input to \"${temp_file}\""

--- a/vipe.sh
+++ b/vipe.sh
@@ -49,14 +49,17 @@ then :; else
 fi
 trap clean_up EXIT
 
+
 if cat - > "${temp_file}"
 then :; else
 	err cat "${?}" "Failed to save standard input to \"${temp_file}\""
 fi
 
-if ${editor} "${temp_file}" < /dev/tty > /dev/tty
-then :; else
-	err "${editor}" "${?}" "Exited with non-zero status"
+if [ ! -t 0 ]; then
+	if ${editor} "${temp_file}" < /dev/tty > /dev/tty
+	then :; else
+		err "${editor}" "${?}" "Exited with non-zero status"
+	fi
 fi
 
 if cat "${temp_file}"


### PR DESCRIPTION
With empty stdin (when there's no piped input), `cat -` waits for input. This makes `vipe` freeze in line 52: https://github.com/0mp/vipe.sh/blob/6ed8f4321e2719171aeebc0ea19e210e4003279b/vipe.sh#L52.

I've added a `if [ ! -t 0 ]` check before the `cat -` expression which skips reading from stdin in such case.

The tool's functionality remains intact, e.g. all combinations of piping/not piping/to/from vipe work.

![vipe](https://github.com/user-attachments/assets/aa769c7e-4a02-487a-a234-aef8445f7c54)